### PR TITLE
Dynamic Product Carousel Replacing Videos

### DIFF
--- a/style.css
+++ b/style.css
@@ -39,11 +39,11 @@ Author URI: https://iconcommerce.com
 }
 
 #carousel-2 .carousel-track {
-  animation: scroll 15s linear infinite;
+  animation: scroll 10s linear infinite;
 }
 
 #carousel-3 .carousel-track {
-  animation: scroll-reverse 15s linear infinite;
+  animation: scroll-reverse 10s linear infinite;
 }
 
 .image-carousel .carousel-item {

--- a/style.css
+++ b/style.css
@@ -26,36 +26,42 @@ Author URI: https://iconcommerce.com
   /* Full screen height */
   overflow: hidden;
   position: relative;
-  animation: fadeIn 1s linear infinite;
+  /* animation: fadeIn 1s linear infinite; */
 }
 
-.image-carousel--reverse .carousel-track {
-  animation: scroll 10s linear infinite;
-}
 
 .carousel-track {
-  height: 200%;
-  /* Enough height to fit all images */
+  height: auto;
   animation: scroll-reverse 10s linear infinite;
   /* Adjust time for different speeds */
   display: flex;
   flex-direction: column;
 }
 
+#carousel-2 .carousel-track {
+  animation: scroll 15s linear infinite;
+}
+
+#carousel-3 .carousel-track {
+  animation: scroll-reverse 15s linear infinite;
+}
+
 .image-carousel .carousel-item {
   width: 100%;
-  height: 25%;
+  height: 20%;
   /* Adjust based on the number of images */
   padding-top: 30px;
   padding-bottom: 30px;
+  text-align: center;
 }
 
 .image-carousel .carousel-item img {
-  width: 100%;
-  height: 100%;
+  width: 80%;
+  height: auto;
   /* Adjust based on the number of images */
   object-fit: contain;
   max-height: 100% !important;
+  margin: 0 auto;
 }
 
 /* Keyframes to create the continuous scrolling effect */

--- a/style.css
+++ b/style.css
@@ -8,8 +8,84 @@ Author URI: https://iconcommerce.com
 */
 
 /*Add your own styles here:*/
-/* Test l */ 
+/* Test l */
 
 .test-1 {
   display: none;
+}
+
+.overflow-hidden {
+  overflow: hidden;
+}
+
+/* Homepage Image Carousels */
+
+.image-carousel {
+  width: 100%;
+  height: 100vh;
+  /* Full screen height */
+  overflow: hidden;
+  position: relative;
+  animation: fadeIn 1s linear infinite;
+}
+
+.image-carousel--reverse .carousel-track {
+  animation: scroll 10s linear infinite;
+}
+
+.carousel-track {
+  height: 200%;
+  /* Enough height to fit all images */
+  animation: scroll-reverse 10s linear infinite;
+  /* Adjust time for different speeds */
+  display: flex;
+  flex-direction: column;
+}
+
+.image-carousel .carousel-item {
+  width: 100%;
+  height: 25%;
+  /* Adjust based on the number of images */
+  padding-top: 30px;
+  padding-bottom: 30px;
+}
+
+.image-carousel .carousel-item img {
+  width: 100%;
+  height: 100%;
+  /* Adjust based on the number of images */
+  object-fit: contain;
+  max-height: 100% !important;
+}
+
+/* Keyframes to create the continuous scrolling effect */
+@keyframes scroll {
+  from {
+    transform: translateY(0);
+  }
+
+  to {
+    transform: translateY(-50%);
+    /* Move up by half the height of the container */
+  }
+}
+@keyframes scroll-reverse {
+  from {
+    transform: translateY(-50%);
+  }
+
+  to {
+    transform: translateY(0%);
+    /* Move up by half the height of the container */
+  }
+}
+
+// animation to fade in opacity
+@keyframes fadeIn {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
 }

--- a/style.css
+++ b/style.css
@@ -50,8 +50,7 @@ Author URI: https://iconcommerce.com
   width: 100%;
   height: 20%;
   /* Adjust based on the number of images */
-  padding-top: 30px;
-  padding-bottom: 30px;
+  padding: 15%;
   text-align: center;
 }
 

--- a/template-parts/snack-pedestal.php
+++ b/template-parts/snack-pedestal.php
@@ -32,7 +32,7 @@ if(!class_exists('Icon_Snack_Pedestal_Shortcode')) {
       if (!$product_category) {
         $product_category = '';
       }
-      echo '<div class="w-separator us_custom_c553b43d size_custom" id="pedestal" style="height:155px"><span class="pedestal__title"><span class="pedestal__title-label font--semi">Category: </span><span class="pedestal__title-value font--bold">' . $product_category . '</span> </span></div>';
+      echo '<div class="w-separator us_custom_c553b43d size_custom" id="pedestal" style="height:155px"><span class="pedestal__title"><span class="pedestal__title-label font--semi" style="display:none !important;">Category: </span><span class="pedestal__title-value font--bold">' . $product_category . '</span> </span></div>';
 
       // Get the contents of the buffer and end buffering
       $output = ob_get_clean();

--- a/templates/template-home.php
+++ b/templates/template-home.php
@@ -187,11 +187,12 @@ $product_carousel_2 = get_field('carousel_products_2');
               <?php while (have_rows('carousel_products_1')) : the_row(); ?>
                 <?php
                 $product = get_sub_field('product');
+                $color = get_sub_field('product_background');
                 $product_images = get_field('product_images', $product);
                 if ($product_images) :
                   $first_image = $product_images[0];
                 ?>
-                  <div class="carousel-item">
+                  <div class="carousel-item" style="background-color: <?=$color?>">
                     <img src="<?php echo $first_image['url']; ?>" alt="<?php echo $first_image['alt']; ?>">
                   </div>
                 <?php endif; ?>
@@ -201,11 +202,12 @@ $product_carousel_2 = get_field('carousel_products_2');
               <?php while (have_rows('carousel_products_1')) : the_row(); ?>
                 <?php
                 $product = get_sub_field('product');
+                $color = get_sub_field('product_background');
                 $product_images = get_field('product_images', $product);
                 if ($product_images) :
                   $first_image = $product_images[0];
                 ?>
-                  <div class="carousel-item">
+                  <div class="carousel-item" style="background-color: <?=$color?>">
                     <img src="<?php echo $first_image['url']; ?>" alt="<?php echo $first_image['alt']; ?>">
                   </div>
                 <?php endif; ?>
@@ -343,11 +345,12 @@ $product_carousel_2 = get_field('carousel_products_2');
               <?php while (have_rows('carousel_products_2')) : the_row(); ?>
                 <?php
                 $product = get_sub_field('product');
+                $color = get_sub_field('product_background');
                 $product_images = get_field('product_images', $product);
                 if ($product_images) :
                   $first_image = $product_images[0];
                 ?>
-                  <div class="carousel-item">
+                  <div class="carousel-item" style="background-color: <?=$color?>">
                     <img src="<?php echo $first_image['url']; ?>" alt="<?php echo $first_image['alt']; ?>">
                   </div>
                 <?php endif; ?>
@@ -357,11 +360,12 @@ $product_carousel_2 = get_field('carousel_products_2');
               <?php while (have_rows('carousel_products_2')) : the_row(); ?>
                 <?php
                 $product = get_sub_field('product');
+                $color = get_sub_field('product_background');
                 $product_images = get_field('product_images', $product);
                 if ($product_images) :
                   $first_image = $product_images[0];
                 ?>
-                  <div class="carousel-item">
+                  <div class="carousel-item" style="background-color: <?=$color?>">
                     <img src="<?php echo $first_image['url']; ?>" alt="<?php echo $first_image['alt']; ?>">
                   </div>
                 <?php endif; ?>
@@ -386,11 +390,12 @@ $product_carousel_2 = get_field('carousel_products_2');
               <?php while (have_rows('carousel_products_1')) : the_row(); ?>
                 <?php
                 $product = get_sub_field('product');
+                $color = get_sub_field('product_background');
                 $product_images = get_field('product_images', $product);
                 if ($product_images) :
                   $first_image = $product_images[0];
                 ?>
-                  <div class="carousel-item">
+                  <div class="carousel-item" style="background-color: <?=$color?>">
                     <img src="<?php echo $first_image['url']; ?>" alt="<?php echo $first_image['alt']; ?>">
                   </div>
                 <?php endif; ?>
@@ -400,11 +405,12 @@ $product_carousel_2 = get_field('carousel_products_2');
               <?php while (have_rows('carousel_products_1')) : the_row(); ?>
                 <?php
                 $product = get_sub_field('product');
+                $color = get_sub_field('product_background');
                 $product_images = get_field('product_images', $product);
                 if ($product_images) :
                   $first_image = $product_images[0];
                 ?>
-                  <div class="carousel-item">
+                  <div class="carousel-item" style="background-color: <?=$color?>">
                     <img src="<?php echo $first_image['url']; ?>" alt="<?php echo $first_image['alt']; ?>">
                   </div>
                 <?php endif; ?>

--- a/templates/template-home.php
+++ b/templates/template-home.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Template Name: HomePage Template
  * Template Post Type: page
@@ -13,36 +14,33 @@ get_header();
 
 <!--Font Hack for Home-->
 <style>
+  @font-face {
+    font-family: "brice-black-semicondensed-local";
+    src: url("/wp-content/themes/ovh/fonts/brice/Brice-BlackSemiCondensed.otf");
+    /*src: url("../fonts/brice/Brice-BlackSemiCondensed.otf");*/
+    font-display: auto;
+    font-style: normal;
+    font-weight: 900;
+    font-stretch: normal
+  }
 
-    
-    @font-face {
-        font-family: "brice-black-semicondensed-local";
-        src: url("/wp-content/themes/ovh/fonts/brice/Brice-BlackSemiCondensed.otf");
-        /*src: url("../fonts/brice/Brice-BlackSemiCondensed.otf");*/
-        font-display: auto;
-        font-style: normal;
-        font-weight: 900;
-        font-stretch: normal
-    }
+  .brice-black-semicondensed-local {
+    font-family: brice-black-semicondensed-local, sans-serif !important
+  }
 
-    .brice-black-semicondensed-local {
-        font-family: brice-black-semicondensed-local,sans-serif!important
-    }
-    
-    @font-face {
-        font-family: "brice-regular-local";
-        src: url("/wp-content/themes/ovh/fonts/brice/Brice-Regular.otf");
-        /*src: url("../fonts/brice/Brice-Regular.otf");*/
-        font-display: auto;
-        font-style: normal;
-        font-weight: 400;
-        font-stretch: normal
-    }
-    .brice-reg {
-        font-family: brice-regular-local,sans-serif!important
-    }
+  @font-face {
+    font-family: "brice-regular-local";
+    src: url("/wp-content/themes/ovh/fonts/brice/Brice-Regular.otf");
+    /*src: url("../fonts/brice/Brice-Regular.otf");*/
+    font-display: auto;
+    font-style: normal;
+    font-weight: 400;
+    font-stretch: normal
+  }
 
-
+  .brice-reg {
+    font-family: brice-regular-local, sans-serif !important
+  }
 </style>
 
 
@@ -51,119 +49,119 @@ get_header();
 
 <div class="home-mobile mhome-container">
 
-    <div class="mhome-1 w-100 mhome-row mhome-item" >
-        <img width="365" height="130" src="/wp-content/uploads/2023/01/Group-694.png" class="attachment-full size-full" alt="" decoding="async" loading="lazy" srcset="/wp-content/uploads/2023/01/Group-694.png 365w, /wp-content/uploads/2023/01/Group-694-300x107.png 300w" sizes="(max-width: 365px) 100vw, 365px">
+  <div class="mhome-1 w-100 mhome-row mhome-item">
+    <img width="365" height="130" src="/wp-content/uploads/2023/01/Group-694.png" class="attachment-full size-full" alt="" decoding="async" loading="lazy" srcset="/wp-content/uploads/2023/01/Group-694.png 365w, /wp-content/uploads/2023/01/Group-694-300x107.png 300w" sizes="(max-width: 365px) 100vw, 365px">
+  </div>
+  <div class="mhome-2 w-100 mhome-row">
+    <div class="w-50 mhome-2-1 mhome-item">
+      <!--            <img class="center-image" src="https://orchardvalleyharvest.com/wp-content/uploads/2023/01/NutGroup.png" alt="A variety of nuts">-->
+      <img class="center-image" src="/wp-content/uploads/2023/01/NutGroup.png" alt="A variety of nuts">
     </div>
-    <div class="mhome-2 w-100 mhome-row">
-        <div class="w-50 mhome-2-1 mhome-item">
-<!--            <img class="center-image" src="https://orchardvalleyharvest.com/wp-content/uploads/2023/01/NutGroup.png" alt="A variety of nuts">-->
-            <img class="center-image" src="/wp-content/uploads/2023/01/NutGroup.png" alt="A variety of nuts">
-        </div>
-        <div class="w-50 mhome-2-2 mhome-item">
-<!--            <img class="center-image" src="https://orchardvalleyh.wpengine.com/wp-content/uploads/2022/12/Group-794.png" alt="">-->
-            <img class="center-image" src="/wp-content/uploads/2022/12/Group-794.png" alt="">
-        </div>
+    <div class="w-50 mhome-2-2 mhome-item">
+      <!--            <img class="center-image" src="https://orchardvalleyh.wpengine.com/wp-content/uploads/2022/12/Group-794.png" alt="">-->
+      <img class="center-image" src="/wp-content/uploads/2022/12/Group-794.png" alt="">
     </div>
-<!--  Video  -->
-    <div class="mhome-3 w-100 mhome-row mhome-item mhome-item-video">
-        <div class="home-video">
-            <video autoplay muted loop>
-                <source src="/wp-content/uploads/2023/02/PR1.mp4" type="video/mp4" />
-            </video>
-        </div>
+  </div>
+  <!--  Video  -->
+  <div class="mhome-3 w-100 mhome-row mhome-item mhome-item-video">
+    <div class="home-video">
+      <video autoplay muted loop>
+        <source src="/wp-content/uploads/2023/02/PR1.mp4" type="video/mp4" />
+      </video>
     </div>
-<!--  Pledge  -->
-    <div class="mhome-4 w-100 mhome-row mhome-item">
-        <img src="/wp-content/uploads/2022/12/Group-755-1.png">
-        <div class="home-btn-wrapper align_right home-link brice-black-semicondensed-local"><a class="w-btn us-btn-style_1" title="Find Out More" href="/find-out-more/"><span class="w-btn-label">Find Out More</span></a></div>
+  </div>
+  <!--  Pledge  -->
+  <div class="mhome-4 w-100 mhome-row mhome-item">
+    <img src="/wp-content/uploads/2022/12/Group-755-1.png">
+    <div class="home-btn-wrapper align_right home-link brice-black-semicondensed-local"><a class="w-btn us-btn-style_1" title="Find Out More" href="/find-out-more/"><span class="w-btn-label">Find Out More</span></a></div>
+  </div>
+  <!-- Friends -->
+  <div class="mhome-5 w-100 mhome-row mhome-item">
+    <img class="center-image" src="/wp-content/uploads/2022/12/Group-795.png">
+  </div>
+  <div class="mhome-6 w-100 mhome-row mhome-item">
+    <img class="center-image" src="/wp-content/uploads/2022/12/Group-702.png">
+  </div>
+
+  <div class="mhome-7 w-100 mhome-row">
+    <div class="w-50 mhome-7-1 mhome-item">
+      <img width="168" height="351" src="/wp-content/uploads/2023/01/Group-696.png" class="attachment-full size-full" alt="" decoding="async" loading="lazy" srcset="/wp-content/uploads/2023/01/Group-696.png 168w, /wp-content/uploads/2023/01/Group-696-144x300.png 144w" sizes="(max-width: 168px) 100vw, 168px">
     </div>
-<!-- Friends -->
-    <div class="mhome-5 w-100 mhome-row mhome-item">
-            <img class="center-image" src="/wp-content/uploads/2022/12/Group-795.png">
+    <div class="w-50 mhome-7-2 mhome-item">
+      <img width="256" height="405" src="/wp-content/uploads/2023/01/Group-697.png" class="attachment-full size-full" alt="" decoding="async" loading="lazy" srcset="/wp-content/uploads/2023/01/Group-697.png 256w, /wp-content/uploads/2023/01/Group-697-190x300.png 190w" sizes="(max-width: 256px) 100vw, 256px">
     </div>
-    <div class="mhome-6 w-100 mhome-row mhome-item">
-            <img class="center-image" src="/wp-content/uploads/2022/12/Group-702.png">
+  </div>
+
+  <div class="mhome-8 w-100 mhome-row mhome-item">
+    <img width="238" height="201" src="/wp-content/uploads/2023/01/Group-698.png" class="attachment-full size-full" alt="" decoding="async" loading="lazy">
+  </div>
+
+  <div class="mhome-9 w-100 mhome-row mhome-item">
+    <p class="brice-reg">Conscious Alliance support and feeds America's communities by sorting, packing and moving truckloads of healthy food - like our OVH snacks - to those in need.</p>
+    <a class="home-link brice-black-semicondensed-local" target="_blank" href="https://consciousalliance.org/">FIND OUT MORE</a>
+  </div>
+
+  <div class="mhome-10 w-100 mhome-row mhome-item mhome-board">
+
+    <div class="board-frame board-1 board-h1" style="background-image: url(https://orchardvalleyharvest.com/wp-content/uploads/2022/12/Frame2.png)">
+      <div class="board-frame-inner"></div>
+      <div class="board-pin"></div>
+      <div class="board-frame-image" style="background-image: url(https://orchardvalleyharvest.com/wp-content/uploads/2022/12/Image1.png)"></div>
+      <div class="board-frame-text brice-black-semicondensed">OVH supporting Conscious Alliance at The String Cheese Incident, Red Rocks, Colorado</div>
     </div>
 
-    <div class="mhome-7 w-100 mhome-row">
-        <div class="w-50 mhome-7-1 mhome-item">
-            <img width="168" height="351" src="/wp-content/uploads/2023/01/Group-696.png" class="attachment-full size-full" alt="" decoding="async" loading="lazy" srcset="/wp-content/uploads/2023/01/Group-696.png 168w, /wp-content/uploads/2023/01/Group-696-144x300.png 144w" sizes="(max-width: 168px) 100vw, 168px">
-        </div>
-        <div class="w-50 mhome-7-2 mhome-item">
-            <img width="256" height="405" src="/wp-content/uploads/2023/01/Group-697.png" class="attachment-full size-full" alt="" decoding="async" loading="lazy" srcset="/wp-content/uploads/2023/01/Group-697.png 256w, /wp-content/uploads/2023/01/Group-697-190x300.png 190w" sizes="(max-width: 256px) 100vw, 256px">
-        </div>
+    <div class="board-frame board-4 board-h2" style="background-image: url(https://orchardvalleyharvest.com/wp-content/uploads/2022/12/Frame2.png)">
+      <div class="board-frame-inner"></div>
+      <div class="board-pin"></div>
+      <div class="board-frame-image" style="background-image: url(https://orchardvalleyharvest.com/wp-content/uploads/2022/12/Image2a.png)"></div>
+      <div class="board-frame-text brice-black-semicondensed">OVH supporting Conscious Alliance at The String Cheese Incident, Red Rocks, Colorado</div>
     </div>
 
-    <div class="mhome-8 w-100 mhome-row mhome-item">
-        <img width="238" height="201" src="/wp-content/uploads/2023/01/Group-698.png" class="attachment-full size-full" alt="" decoding="async" loading="lazy">
+  </div>
+
+  <!-- Falling Nuts -->
+  <div class="mhome-11 w-100 mhome-row mhome-item">
+    <video class="home-falling-nuts" autoplay="" loop="" muted="" playsinline="" style="">
+      <source src="/wp-content/uploads/2023/02/FN1-1.mov" type='video/mp4; codecs="hvc1"'>
+      <source src="/wp-content/uploads/2023/02/Falling-Nuts.webm" type="video/webm">
+    </video>
+
+    <div class="home-farmers">
+      <p class="brice-black-condensed">FOUNDED BY FARMERS,</p>
+      <p class="brice-black-condensed text-flair">WE ARE</p>
+      <p class="brice-black-condensed">THE SNACKING BRAND</p>
+      <p class="brice-semibold">THAT BELIEVES</p>
+      <p class="brice-bold">IN BETTER</p>
     </div>
+  </div>
 
-    <div class="mhome-9 w-100 mhome-row mhome-item">
-        <p class="brice-reg">Conscious Alliance support and feeds America's communities by sorting, packing and moving truckloads of healthy food - like our OVH snacks - to those in need.</p>
-        <a class="home-link brice-black-semicondensed-local" target="_blank" href="https://consciousalliance.org/">FIND OUT MORE</a>
+  <!--  Video  -->
+  <div class="mhome-12 w-100 mhome-row mhome-item mhome-item-video">
+    <div class="home-video">
+      <video autoplay muted loop>
+        <source src="/wp-content/uploads/2023/02/PackRoll1-25.webm" type="video/webm" />
+      </video>
     </div>
+  </div>
+  <!-- Good Food -->
+  <div class="mhome-13 w-100 mhome-row mhome-item ">
+    <img width="425" height="277" src="/wp-content/uploads/2022/12/Group-800.png" class="attachment-full size-full" alt="" decoding="async" loading="lazy" srcset="/wp-content/uploads/2022/12/Group-800.png 425w, /wp-content/uploads/2022/12/Group-800-300x196.png 300w" sizes="(max-width: 425px) 100vw, 425px">
+  </div>
 
-    <div class="mhome-10 w-100 mhome-row mhome-item mhome-board">
-
-        <div class="board-frame board-1 board-h1" style="background-image: url(https://orchardvalleyharvest.com/wp-content/uploads/2022/12/Frame2.png)">
-            <div class="board-frame-inner"></div>
-            <div class="board-pin"></div>
-            <div class="board-frame-image" style="background-image: url(https://orchardvalleyharvest.com/wp-content/uploads/2022/12/Image1.png)"></div>
-            <div class="board-frame-text brice-black-semicondensed">OVH supporting Conscious Alliance at The String Cheese Incident, Red Rocks, Colorado</div>
-        </div>
-
-        <div class="board-frame board-4 board-h2" style="background-image: url(https://orchardvalleyharvest.com/wp-content/uploads/2022/12/Frame2.png)">
-            <div class="board-frame-inner"></div>
-            <div class="board-pin"></div>
-            <div class="board-frame-image" style="background-image: url(https://orchardvalleyharvest.com/wp-content/uploads/2022/12/Image2a.png)"></div>
-            <div class="board-frame-text brice-black-semicondensed">OVH supporting Conscious Alliance at The String Cheese Incident, Red Rocks, Colorado</div>
-        </div>
-
+  <!--  Video  -->
+  <div class="mhome-14 w-100 mhome-row mhome-item mhome-item-video">
+    <div class="home-video">
+      <video autoplay muted loop>
+        <source src="/wp-content/uploads/2023/02/PackRoll2-25.webm" type="video/webm" />
+      </video>
     </div>
-
-<!-- Falling Nuts -->
-    <div class="mhome-11 w-100 mhome-row mhome-item">
-        <video class="home-falling-nuts" autoplay="" loop="" muted="" playsinline="" style="">
-            <source src="/wp-content/uploads/2023/02/FN1-1.mov" type='video/mp4; codecs="hvc1"'>
-            <source src="/wp-content/uploads/2023/02/Falling-Nuts.webm" type="video/webm">
-        </video>
-
-        <div class="home-farmers">
-            <p class="brice-black-condensed">FOUNDED BY FARMERS,</p>
-            <p class="brice-black-condensed text-flair">WE ARE</p>
-            <p class="brice-black-condensed">THE SNACKING BRAND</p>
-            <p class="brice-semibold">THAT BELIEVES</p>
-            <p class="brice-bold">IN BETTER</p>
-        </div>
-    </div>
-
-<!--  Video  -->
-    <div class="mhome-12 w-100 mhome-row mhome-item mhome-item-video">
-        <div class="home-video">
-            <video autoplay muted loop>
-                <source src="/wp-content/uploads/2023/02/PackRoll1-25.webm" type="video/webm" />
-            </video>
-        </div>
-    </div>
-<!-- Good Food -->
-    <div class="mhome-13 w-100 mhome-row mhome-item " >
-        <img width="425" height="277" src="/wp-content/uploads/2022/12/Group-800.png" class="attachment-full size-full" alt="" decoding="async" loading="lazy" srcset="/wp-content/uploads/2022/12/Group-800.png 425w, /wp-content/uploads/2022/12/Group-800-300x196.png 300w" sizes="(max-width: 425px) 100vw, 425px">
-    </div>
-
-<!--  Video  -->
-    <div class="mhome-14 w-100 mhome-row mhome-item mhome-item-video">
-        <div class="home-video">
-            <video autoplay muted loop>
-                <source src="/wp-content/uploads/2023/02/PackRoll2-25.webm" type="video/webm" />
-            </video>
-        </div>
-    </div>
+  </div>
 
 
-<!-- Indulge -->
-    <div class="mhome-15 w-100 mhome-row mhome-item" >
-        <img width="363" height="163" src="/wp-content/uploads/2023/01/Group-602.png" class="attachment-full size-full" alt="" decoding="async" loading="lazy" srcset="/wp-content/uploads/2023/01/Group-602.png 363w, /wp-content/uploads/2023/01/Group-602-300x135.png 300w" sizes="(max-width: 363px) 100vw, 363px">
-    </div>
+  <!-- Indulge -->
+  <div class="mhome-15 w-100 mhome-row mhome-item">
+    <img width="363" height="163" src="/wp-content/uploads/2023/01/Group-602.png" class="attachment-full size-full" alt="" decoding="async" loading="lazy" srcset="/wp-content/uploads/2023/01/Group-602.png 363w, /wp-content/uploads/2023/01/Group-602-300x135.png 300w" sizes="(max-width: 363px) 100vw, 363px">
+  </div>
 
 </div>
 
@@ -177,164 +175,186 @@ get_header();
 <div id="home-container-v2">
 
 
-<div class="home-section home-1">
+  <div class="home-section home-1">
     <div class="home-col w-33 home-1-col-1  ">
-        <div class="home-1-sub-1 h-100 home-item">
-            <div class="home-video">
-                <video autoplay muted loop>
-                    <source src="/wp-content/uploads/2023/02/PR1-Slow.mp4" type="video/mp4" />
-                </video>
-            </div>
+      <div class="home-1-sub-1 h-100 home-item overflow-hidden">
+        <div class="image-carousel">
+          <div class="carousel-track">
+            <div class="carousel-item"><img src="http://localhost:10013/wp-content/uploads/2024/02/DP23350_OVH_CranNutMix_1.85oz_SUB-Front.png" alt="Image 1"></div>
+            <div class="carousel-item"><img src="http://localhost:10013/wp-content/uploads/2024/02/DP23350_OVH_SaltedCaramelMunchMix_1.85oz_SUB-Front-1.png" alt="Image 2"></div>
+            <div class="carousel-item"><img src="http://localhost:10013/wp-content/uploads/2024/02/DP23350_OVH_CranNutMix_1.85oz_SUB-Front.png" alt="Image 3"></div>
+            <div class="carousel-item"><img src="http://localhost:10013/wp-content/uploads/2024/02/DP23350_OVH_SaltedCaramelMunchMix_1.85oz_SUB-Front-1.png" alt="Image 4"></div>
+            <!-- Repeat the images to allow for continuous effect -->
+            <div class="carousel-item"><img src="http://localhost:10013/wp-content/uploads/2024/02/DP23350_OVH_CranNutMix_1.85oz_SUB-Front.png" alt="Image 1"></div>
+            <div class="carousel-item"><img src="http://localhost:10013/wp-content/uploads/2024/02/DP23350_OVH_SaltedCaramelMunchMix_1.85oz_SUB-Front-1.png" alt="Image 2"></div>
+            <div class="carousel-item"><img src="http://localhost:10013/wp-content/uploads/2024/02/DP23350_OVH_CranNutMix_1.85oz_SUB-Front.png" alt="Image 3"></div>
+            <div class="carousel-item"><img src="http://localhost:10013/wp-content/uploads/2024/02/DP23350_OVH_SaltedCaramelMunchMix_1.85oz_SUB-Front-1.png" alt="Image 4"></div>
+          </div>
         </div>
+      </div>
     </div>
 
     <div class="home-col w-66 home-1-col-2 ">
-        <div class="home-1-sub-2 h-50 home-item">
-            <img class="center-image" src="/wp-content/uploads/2022/12/right-thing.png" alt="">
+      <div class="home-1-sub-2 h-50 home-item">
+        <img class="center-image" src="/wp-content/uploads/2022/12/right-thing.png" alt="">
+      </div>
+      <div class="w-100 h-50 flex-row">
+        <div class="h-100 w-50 home-1-sub-3 home-item">
+          <img class="center-image" src="/wp-content/uploads/2023/01/NutGroup.png" alt="A variety of nuts">
         </div>
-        <div class="w-100 h-50 flex-row">
-            <div class="h-100 w-50 home-1-sub-3 home-item">
-                <img class="center-image" src="/wp-content/uploads/2023/01/NutGroup.png" alt="A variety of nuts">
-            </div>
-            <div class="h-100 w-50 home-1-sub-4 home-item">
-                <img class="center-image" src="/wp-content/uploads/2022/12/Group-794.png" alt="">
-            </div>
+        <div class="h-100 w-50 home-1-sub-4 home-item">
+          <img class="center-image" src="/wp-content/uploads/2022/12/Group-794.png" alt="">
         </div>
+      </div>
     </div>
 
-</div>
+  </div>
 
 
-<div class="home-section home-2">
+  <div class="home-section home-2">
     <div class="home-col w-75 home-2-col-1">
-        <div class="home-2-sub-1 h-100 home-item">
-            <img src="/wp-content/uploads/2022/12/Group-755-1.png">
-            <div class="home-btn-wrapper align_right home-link brice-black-semicondensed-local"><a class="w-btn us-btn-style_1" title="Find Out More" href="/find-out-more/"><span class="w-btn-label">Find Out More</span></a></div>
-        </div>
+      <div class="home-2-sub-1 h-100 home-item">
+        <img src="/wp-content/uploads/2022/12/Group-755-1.png">
+        <div class="home-btn-wrapper align_right home-link brice-black-semicondensed-local"><a class="w-btn us-btn-style_1" title="Find Out More" href="/find-out-more/"><span class="w-btn-label">Find Out More</span></a></div>
+      </div>
 
     </div>
     <div class="home-col w-25 home-2-col-2">
-        <div class="home-2-sub-2 h-50 home-item">
-            <img class="center-image" src="/wp-content/uploads/2022/12/Group-795.png">
-        </div>
-        <div class="home-2-sub-3 h-50 home-item">
-            <img class="center-image" src="/wp-content/uploads/2022/12/Group-702.png">
-        </div>
+      <div class="home-2-sub-2 h-50 home-item">
+        <img class="center-image" src="/wp-content/uploads/2022/12/Group-795.png">
+      </div>
+      <div class="home-2-sub-3 h-50 home-item">
+        <img class="center-image" src="/wp-content/uploads/2022/12/Group-702.png">
+      </div>
     </div>
-</div>
+  </div>
 
 
-<div class="home-section home-3">
+  <div class="home-section home-3">
     <div class="home-col w-33 home-3-col-1">
-        <div class="home-3-sub-1 h-50 home-item">
-            <script src="https://unpkg.com/@lottiefiles/lottie-player@latest/dist/lottie-player.js"></script>
-            <lottie-player class="home-plates-lottie" src="/wp-content/themes/ovh/animations/Plate_Hover_Homepage.json"  background="transparent"  speed="1"  style="width: auto; height: 100%;" hover  ></lottie-player>
-            <!--            <img class="center-image" src="https://orchardvalleyh.wpengine.com/wp-content/uploads/2022/12/Component-5-–-2.png">-->
+      <div class="home-3-sub-1 h-50 home-item">
+        <script src="https://unpkg.com/@lottiefiles/lottie-player@latest/dist/lottie-player.js"></script>
+        <lottie-player class="home-plates-lottie" src="/wp-content/themes/ovh/animations/Plate_Hover_Homepage.json" background="transparent" speed="1" style="width: auto; height: 100%;" hover></lottie-player>
+        <!--            <img class="center-image" src="https://orchardvalleyh.wpengine.com/wp-content/uploads/2022/12/Component-5-–-2.png">-->
+      </div>
+      <div class="home-3-sub-2 h-50 home-item">
+        <div class="home-feed">
+          <p class="brice-bold">FEEDING</p>
+          <p class="brice-black-condensed">A BETTER FUTURE</p>
+          <p class="brice-bold">ONE MEAL</p>
+          <p class="brice-bold">AT A TIME</p>
         </div>
-        <div class="home-3-sub-2 h-50 home-item">
-            <div class="home-feed">
-                <p class="brice-bold">FEEDING</p>
-                <p class="brice-black-condensed">A BETTER FUTURE</p>
-                <p class="brice-bold">ONE MEAL</p>
-                <p class="brice-bold">AT A TIME</p>
-            </div>
-        </div>
+      </div>
     </div>
     <div class="home-col w-66 home-3-col-2">
-        <div class="home-3-sub-3 h-100 home-item home-board-frame">
-            <div class="board-frame board-1 board-h1" style="background-image: url(https://orchardvalleyharvest.com/wp-content/uploads/2022/12/Frame2.png)">
-                <div class="board-frame-inner"></div>
-                <div class="board-pin"></div>
-                <div class="board-frame-image" style="background-image: url(https://orchardvalleyharvest.com/wp-content/uploads/2022/12/Image1.png)"></div>
-                <div class="board-frame-text brice-black-semicondensed">OVH supporting Conscious Alliance at The String Cheese Incident, Red Rocks, Colorado</div>
-            </div>
-
-            <div class="board-frame board-4 board-h2" style="background-image: url(https://orchardvalleyharvest.com/wp-content/uploads/2022/12/Frame2.png)">
-                <div class="board-frame-inner"></div>
-                <div class="board-pin"></div>
-                <div class="board-frame-image" style="background-image: url(https://orchardvalleyharvest.com/wp-content/uploads/2022/12/Image2a.png)"></div>
-                <div class="board-frame-text brice-black-semicondensed">OVH supporting Conscious Alliance at The String Cheese Incident, Red Rocks, Colorado</div>
-            </div>
-
-            <div class="board-link-h1">
-                <div class="brice-bold hl1-1">GET</div>
-                <div class="brice-black-condensed hl1-2">Involved</div>
-                <div class="hl1-5">
-                    <img src="https://orchardvalldev.wpengine.com/wp-content/uploads/2023/02/wave-yellow.gif" alt="Yellow Waving Man">
-<!--                    <video autoplay muted loop>-->
-<!--                        <source src="/wp-content/uploads/2023/02/wave-a-1.mov" type='video/mp4; codecs="hvc1"'>-->
-<!--                        <source src="/wp-content/uploads/2023/02/wave-1.webm" type="video/webm" />-->
-<!--                    </video>-->
-
-
-                </div>
-                <div class="hl1-3">
-                    <p class="brice-reg">Conscious Alliance support and feeds America's communities by sorting, packing and moving truckloads of healthy food - like our OVH snacks - to those in need.</p>
-                    <a class="hl1-4 home-link brice-black-semicondensed-local" target="_blank" href="https://consciousalliance.org/">FIND OUT MORE</a>
-                </div>
-            </div>
-
-            <!--            <a target="_blank" href="https://consciousalliance.org/"><img class="center-image" src="https://orchardvalleyh.wpengine.com/wp-content/uploads/2022/12/Mask-Group-525.png" alt=""></a>-->
+      <div class="home-3-sub-3 h-100 home-item home-board-frame">
+        <div class="board-frame board-1 board-h1" style="background-image: url(https://orchardvalleyharvest.com/wp-content/uploads/2022/12/Frame2.png)">
+          <div class="board-frame-inner"></div>
+          <div class="board-pin"></div>
+          <div class="board-frame-image" style="background-image: url(https://orchardvalleyharvest.com/wp-content/uploads/2022/12/Image1.png)"></div>
+          <div class="board-frame-text brice-black-semicondensed">OVH supporting Conscious Alliance at The String Cheese Incident, Red Rocks, Colorado</div>
         </div>
+
+        <div class="board-frame board-4 board-h2" style="background-image: url(https://orchardvalleyharvest.com/wp-content/uploads/2022/12/Frame2.png)">
+          <div class="board-frame-inner"></div>
+          <div class="board-pin"></div>
+          <div class="board-frame-image" style="background-image: url(https://orchardvalleyharvest.com/wp-content/uploads/2022/12/Image2a.png)"></div>
+          <div class="board-frame-text brice-black-semicondensed">OVH supporting Conscious Alliance at The String Cheese Incident, Red Rocks, Colorado</div>
+        </div>
+
+        <div class="board-link-h1">
+          <div class="brice-bold hl1-1">GET</div>
+          <div class="brice-black-condensed hl1-2">Involved</div>
+          <div class="hl1-5">
+            <img src="https://orchardvalldev.wpengine.com/wp-content/uploads/2023/02/wave-yellow.gif" alt="Yellow Waving Man">
+            <!--                    <video autoplay muted loop>-->
+            <!--                        <source src="/wp-content/uploads/2023/02/wave-a-1.mov" type='video/mp4; codecs="hvc1"'>-->
+            <!--                        <source src="/wp-content/uploads/2023/02/wave-1.webm" type="video/webm" />-->
+            <!--                    </video>-->
+
+
+          </div>
+          <div class="hl1-3">
+            <p class="brice-reg">Conscious Alliance support and feeds America's communities by sorting, packing and moving truckloads of healthy food - like our OVH snacks - to those in need.</p>
+            <a class="hl1-4 home-link brice-black-semicondensed-local" target="_blank" href="https://consciousalliance.org/">FIND OUT MORE</a>
+          </div>
+        </div>
+
+        <!--            <a target="_blank" href="https://consciousalliance.org/"><img class="center-image" src="https://orchardvalleyh.wpengine.com/wp-content/uploads/2022/12/Mask-Group-525.png" alt=""></a>-->
+      </div>
     </div>
-</div>
+  </div>
 
 
 
-<div class="home-section home-4">
+  <div class="home-section home-4">
     <div class="home-col w-100 home-4-col-1">
 
-        <video class="home-falling-nuts" autoplay="" loop="" muted="" playsinline="" style="">
-            <source src="/wp-content/uploads/2023/02/FN1-1.mov" type='video/mp4; codecs="hvc1"'>
-            <source src="/wp-content/uploads/2023/02/Falling-Nuts.webm" type="video/webm">
-        </video>
+      <video class="home-falling-nuts" autoplay="" loop="" muted="" playsinline="" style="">
+        <source src="/wp-content/uploads/2023/02/FN1-1.mov" type='video/mp4; codecs="hvc1"'>
+        <source src="/wp-content/uploads/2023/02/Falling-Nuts.webm" type="video/webm">
+      </video>
 
 
-        <div class="home-4-sub-1 h-100 home-item">
-            <div class="home-farmers">
-                <p class="brice-black-condensed">FOUNDED BY FARMERS,</p>
-                <p class="brice-black-condensed text-flair">WE ARE</p>
-                <p class="brice-black-condensed">THE SNACKING BRAND</p>
-                <p class="brice-semibold">THAT BELIEVES</p>
-                <p class="brice-bold">IN BETTER</p>
-            </div>
+      <div class="home-4-sub-1 h-100 home-item">
+        <div class="home-farmers">
+          <p class="brice-black-condensed">FOUNDED BY FARMERS,</p>
+          <p class="brice-black-condensed text-flair">WE ARE</p>
+          <p class="brice-black-condensed">THE SNACKING BRAND</p>
+          <p class="brice-semibold">THAT BELIEVES</p>
+          <p class="brice-bold">IN BETTER</p>
         </div>
+      </div>
     </div>
-</div>
+  </div>
 
 
 
 
 
-<div class="home-section home-5">
+  <div class="home-section home-5">
     <div class="home-col w-50 home-5-col-1  ">
-        <div class="home-5-sub-1 h-70 home-item">
-            <div class="home-video">
-
-                <video autoplay muted loop>
-                    <source src="/wp-content/uploads/2023/02/PR1-Slow.mp4" type="video/mp4" />
-                </video>
-
-            </div>
+      <div class="home-5-sub-1 h-70 home-item overflow-hidden">
+        <div class="image-carousel">
+          <div class="carousel-track">
+            <div class="carousel-item"><img src="http://localhost:10013/wp-content/uploads/2024/02/DP23350_OVH_CranNutMix_1.85oz_SUB-Front.png" alt="Image 1"></div>
+            <div class="carousel-item"><img src="http://localhost:10013/wp-content/uploads/2024/02/DP23350_OVH_SaltedCaramelMunchMix_1.85oz_SUB-Front-1.png" alt="Image 2"></div>
+            <div class="carousel-item"><img src="http://localhost:10013/wp-content/uploads/2024/02/DP23350_OVH_CranNutMix_1.85oz_SUB-Front.png" alt="Image 3"></div>
+            <div class="carousel-item"><img src="http://localhost:10013/wp-content/uploads/2024/02/DP23350_OVH_SaltedCaramelMunchMix_1.85oz_SUB-Front-1.png" alt="Image 4"></div>
+            <!-- Repeat the images to allow for continuous effect -->
+            <div class="carousel-item"><img src="http://localhost:10013/wp-content/uploads/2024/02/DP23350_OVH_CranNutMix_1.85oz_SUB-Front.png" alt="Image 1"></div>
+            <div class="carousel-item"><img src="http://localhost:10013/wp-content/uploads/2024/02/DP23350_OVH_SaltedCaramelMunchMix_1.85oz_SUB-Front-1.png" alt="Image 2"></div>
+            <div class="carousel-item"><img src="http://localhost:10013/wp-content/uploads/2024/02/DP23350_OVH_CranNutMix_1.85oz_SUB-Front.png" alt="Image 3"></div>
+            <div class="carousel-item"><img src="http://localhost:10013/wp-content/uploads/2024/02/DP23350_OVH_SaltedCaramelMunchMix_1.85oz_SUB-Front-1.png" alt="Image 4"></div>
+          </div>
         </div>
-        <div class="home-5-sub-2 h-30 home-item">
-            <img class="center-image" src="/wp-content/uploads/2022/12/Group-800.png" alt="">
-        </div>
+      </div>
+      <div class="home-5-sub-2 h-30 home-item">
+        <img class="center-image" src="/wp-content/uploads/2022/12/Group-800.png" alt="">
+      </div>
     </div>
 
     <div class="home-col w-50 home-5-col-2 ">
-        <div class="home-5-sub-3 h-30 home-item">
-            <img class="center-image" src="/wp-content/uploads/2022/12/Group-740.png" alt="">
+      <div class="home-5-sub-3 h-30 home-item">
+        <img class="center-image" src="/wp-content/uploads/2022/12/Group-740.png" alt="">
+      </div>
+      <div class="home-5-sub-4 h-70 home-item overflow-hidden">
+        <div class="image-carousel image-carousel--reverse">
+          <div class="carousel-track">
+            <div class="carousel-item"><img src="http://localhost:10013/wp-content/uploads/2024/02/DP23350_OVH_CranNutMix_1.85oz_SUB-Front.png" alt="Image 1"></div>
+            <div class="carousel-item"><img src="http://localhost:10013/wp-content/uploads/2024/02/DP23350_OVH_SaltedCaramelMunchMix_1.85oz_SUB-Front-1.png" alt="Image 2"></div>
+            <div class="carousel-item"><img src="http://localhost:10013/wp-content/uploads/2024/02/DP23350_OVH_CranNutMix_1.85oz_SUB-Front.png" alt="Image 3"></div>
+            <div class="carousel-item"><img src="http://localhost:10013/wp-content/uploads/2024/02/DP23350_OVH_SaltedCaramelMunchMix_1.85oz_SUB-Front-1.png" alt="Image 4"></div>
+            <!-- Repeat the images to allow for continuous effect -->
+            <div class="carousel-item"><img src="http://localhost:10013/wp-content/uploads/2024/02/DP23350_OVH_CranNutMix_1.85oz_SUB-Front.png" alt="Image 1"></div>
+            <div class="carousel-item"><img src="http://localhost:10013/wp-content/uploads/2024/02/DP23350_OVH_SaltedCaramelMunchMix_1.85oz_SUB-Front-1.png" alt="Image 2"></div>
+            <div class="carousel-item"><img src="http://localhost:10013/wp-content/uploads/2024/02/DP23350_OVH_CranNutMix_1.85oz_SUB-Front.png" alt="Image 3"></div>
+            <div class="carousel-item"><img src="http://localhost:10013/wp-content/uploads/2024/02/DP23350_OVH_SaltedCaramelMunchMix_1.85oz_SUB-Front-1.png" alt="Image 4"></div>
+          </div>
         </div>
-        <div class="home-5-sub-4 h-70 home-item">
-            <div class="home-video">
-                <video autoplay muted loop>
-                    <source src="/wp-content/uploads/2023/02/PR2-Slow.mp4" type="video/mp4" />
-                </video>
-            </div>
-        </div>
+      </div>
     </div>
-</div>
+  </div>
 
 </div>
 

--- a/templates/template-home.php
+++ b/templates/template-home.php
@@ -43,8 +43,11 @@ get_header();
   }
 </style>
 
-
-
+<?php
+// get the acf field product_carousel
+$product_carousel_1 = get_field('carousel_products_1');
+$product_carousel_2 = get_field('carousel_products_2');
+?>
 
 
 <div class="home-mobile mhome-container">
@@ -180,15 +183,34 @@ get_header();
       <div class="home-1-sub-1 h-100 home-item overflow-hidden">
         <div class="image-carousel">
           <div class="carousel-track">
-            <div class="carousel-item"><img src="http://localhost:10013/wp-content/uploads/2024/02/DP23350_OVH_CranNutMix_1.85oz_SUB-Front.png" alt="Image 1"></div>
-            <div class="carousel-item"><img src="http://localhost:10013/wp-content/uploads/2024/02/DP23350_OVH_SaltedCaramelMunchMix_1.85oz_SUB-Front-1.png" alt="Image 2"></div>
-            <div class="carousel-item"><img src="http://localhost:10013/wp-content/uploads/2024/02/DP23350_OVH_CranNutMix_1.85oz_SUB-Front.png" alt="Image 3"></div>
-            <div class="carousel-item"><img src="http://localhost:10013/wp-content/uploads/2024/02/DP23350_OVH_SaltedCaramelMunchMix_1.85oz_SUB-Front-1.png" alt="Image 4"></div>
-            <!-- Repeat the images to allow for continuous effect -->
-            <div class="carousel-item"><img src="http://localhost:10013/wp-content/uploads/2024/02/DP23350_OVH_CranNutMix_1.85oz_SUB-Front.png" alt="Image 1"></div>
-            <div class="carousel-item"><img src="http://localhost:10013/wp-content/uploads/2024/02/DP23350_OVH_SaltedCaramelMunchMix_1.85oz_SUB-Front-1.png" alt="Image 2"></div>
-            <div class="carousel-item"><img src="http://localhost:10013/wp-content/uploads/2024/02/DP23350_OVH_CranNutMix_1.85oz_SUB-Front.png" alt="Image 3"></div>
-            <div class="carousel-item"><img src="http://localhost:10013/wp-content/uploads/2024/02/DP23350_OVH_SaltedCaramelMunchMix_1.85oz_SUB-Front-1.png" alt="Image 4"></div>
+            <?php if (have_rows('carousel_products_1')) : ?>
+              <?php while (have_rows('carousel_products_1')) : the_row(); ?>
+                <?php
+                $product = get_sub_field('product');
+                $product_images = get_field('product_images', $product);
+                if ($product_images) :
+                  $first_image = $product_images[0];
+                ?>
+                  <div class="carousel-item">
+                    <img src="<?php echo $first_image['url']; ?>" alt="<?php echo $first_image['alt']; ?>">
+                  </div>
+                <?php endif; ?>
+              <?php endwhile; ?>
+            <?php endif; ?>
+            <?php if (have_rows('carousel_products_1')) : ?>
+              <?php while (have_rows('carousel_products_1')) : the_row(); ?>
+                <?php
+                $product = get_sub_field('product');
+                $product_images = get_field('product_images', $product);
+                if ($product_images) :
+                  $first_image = $product_images[0];
+                ?>
+                  <div class="carousel-item">
+                    <img src="<?php echo $first_image['url']; ?>" alt="<?php echo $first_image['alt']; ?>">
+                  </div>
+                <?php endif; ?>
+              <?php endwhile; ?>
+            <?php endif; ?>
           </div>
         </div>
       </div>
@@ -315,17 +337,36 @@ get_header();
   <div class="home-section home-5">
     <div class="home-col w-50 home-5-col-1  ">
       <div class="home-5-sub-1 h-70 home-item overflow-hidden">
-        <div class="image-carousel">
+        <div id="carousel-2" class="image-carousel">
           <div class="carousel-track">
-            <div class="carousel-item"><img src="http://localhost:10013/wp-content/uploads/2024/02/DP23350_OVH_CranNutMix_1.85oz_SUB-Front.png" alt="Image 1"></div>
-            <div class="carousel-item"><img src="http://localhost:10013/wp-content/uploads/2024/02/DP23350_OVH_SaltedCaramelMunchMix_1.85oz_SUB-Front-1.png" alt="Image 2"></div>
-            <div class="carousel-item"><img src="http://localhost:10013/wp-content/uploads/2024/02/DP23350_OVH_CranNutMix_1.85oz_SUB-Front.png" alt="Image 3"></div>
-            <div class="carousel-item"><img src="http://localhost:10013/wp-content/uploads/2024/02/DP23350_OVH_SaltedCaramelMunchMix_1.85oz_SUB-Front-1.png" alt="Image 4"></div>
-            <!-- Repeat the images to allow for continuous effect -->
-            <div class="carousel-item"><img src="http://localhost:10013/wp-content/uploads/2024/02/DP23350_OVH_CranNutMix_1.85oz_SUB-Front.png" alt="Image 1"></div>
-            <div class="carousel-item"><img src="http://localhost:10013/wp-content/uploads/2024/02/DP23350_OVH_SaltedCaramelMunchMix_1.85oz_SUB-Front-1.png" alt="Image 2"></div>
-            <div class="carousel-item"><img src="http://localhost:10013/wp-content/uploads/2024/02/DP23350_OVH_CranNutMix_1.85oz_SUB-Front.png" alt="Image 3"></div>
-            <div class="carousel-item"><img src="http://localhost:10013/wp-content/uploads/2024/02/DP23350_OVH_SaltedCaramelMunchMix_1.85oz_SUB-Front-1.png" alt="Image 4"></div>
+            <?php if (have_rows('carousel_products_2')) : ?>
+              <?php while (have_rows('carousel_products_2')) : the_row(); ?>
+                <?php
+                $product = get_sub_field('product');
+                $product_images = get_field('product_images', $product);
+                if ($product_images) :
+                  $first_image = $product_images[0];
+                ?>
+                  <div class="carousel-item">
+                    <img src="<?php echo $first_image['url']; ?>" alt="<?php echo $first_image['alt']; ?>">
+                  </div>
+                <?php endif; ?>
+              <?php endwhile; ?>
+            <?php endif; ?>
+            <?php if (have_rows('carousel_products_2')) : ?>
+              <?php while (have_rows('carousel_products_2')) : the_row(); ?>
+                <?php
+                $product = get_sub_field('product');
+                $product_images = get_field('product_images', $product);
+                if ($product_images) :
+                  $first_image = $product_images[0];
+                ?>
+                  <div class="carousel-item">
+                    <img src="<?php echo $first_image['url']; ?>" alt="<?php echo $first_image['alt']; ?>">
+                  </div>
+                <?php endif; ?>
+              <?php endwhile; ?>
+            <?php endif; ?>
           </div>
         </div>
       </div>
@@ -339,17 +380,36 @@ get_header();
         <img class="center-image" src="/wp-content/uploads/2022/12/Group-740.png" alt="">
       </div>
       <div class="home-5-sub-4 h-70 home-item overflow-hidden">
-        <div class="image-carousel image-carousel--reverse">
+        <div id="carousel-3" class="image-carousel">
           <div class="carousel-track">
-            <div class="carousel-item"><img src="http://localhost:10013/wp-content/uploads/2024/02/DP23350_OVH_CranNutMix_1.85oz_SUB-Front.png" alt="Image 1"></div>
-            <div class="carousel-item"><img src="http://localhost:10013/wp-content/uploads/2024/02/DP23350_OVH_SaltedCaramelMunchMix_1.85oz_SUB-Front-1.png" alt="Image 2"></div>
-            <div class="carousel-item"><img src="http://localhost:10013/wp-content/uploads/2024/02/DP23350_OVH_CranNutMix_1.85oz_SUB-Front.png" alt="Image 3"></div>
-            <div class="carousel-item"><img src="http://localhost:10013/wp-content/uploads/2024/02/DP23350_OVH_SaltedCaramelMunchMix_1.85oz_SUB-Front-1.png" alt="Image 4"></div>
-            <!-- Repeat the images to allow for continuous effect -->
-            <div class="carousel-item"><img src="http://localhost:10013/wp-content/uploads/2024/02/DP23350_OVH_CranNutMix_1.85oz_SUB-Front.png" alt="Image 1"></div>
-            <div class="carousel-item"><img src="http://localhost:10013/wp-content/uploads/2024/02/DP23350_OVH_SaltedCaramelMunchMix_1.85oz_SUB-Front-1.png" alt="Image 2"></div>
-            <div class="carousel-item"><img src="http://localhost:10013/wp-content/uploads/2024/02/DP23350_OVH_CranNutMix_1.85oz_SUB-Front.png" alt="Image 3"></div>
-            <div class="carousel-item"><img src="http://localhost:10013/wp-content/uploads/2024/02/DP23350_OVH_SaltedCaramelMunchMix_1.85oz_SUB-Front-1.png" alt="Image 4"></div>
+            <?php if (have_rows('carousel_products_1')) : ?>
+              <?php while (have_rows('carousel_products_1')) : the_row(); ?>
+                <?php
+                $product = get_sub_field('product');
+                $product_images = get_field('product_images', $product);
+                if ($product_images) :
+                  $first_image = $product_images[0];
+                ?>
+                  <div class="carousel-item">
+                    <img src="<?php echo $first_image['url']; ?>" alt="<?php echo $first_image['alt']; ?>">
+                  </div>
+                <?php endif; ?>
+              <?php endwhile; ?>
+            <?php endif; ?>
+            <?php if (have_rows('carousel_products_1')) : ?>
+              <?php while (have_rows('carousel_products_1')) : the_row(); ?>
+                <?php
+                $product = get_sub_field('product');
+                $product_images = get_field('product_images', $product);
+                if ($product_images) :
+                  $first_image = $product_images[0];
+                ?>
+                  <div class="carousel-item">
+                    <img src="<?php echo $first_image['url']; ?>" alt="<?php echo $first_image['alt']; ?>">
+                  </div>
+                <?php endif; ?>
+              <?php endwhile; ?>
+            <?php endif; ?>
           </div>
         </div>
       </div>

--- a/templates/template-home.php
+++ b/templates/template-home.php
@@ -67,10 +67,39 @@ $product_carousel_2 = get_field('carousel_products_2');
   </div>
   <!--  Video  -->
   <div class="mhome-3 w-100 mhome-row mhome-item mhome-item-video">
-    <div class="home-video">
-      <video autoplay muted loop>
-        <source src="/wp-content/uploads/2023/02/PR1.mp4" type="video/mp4" />
-      </video>
+    <div class="image-carousel">
+      <div class="carousel-track">
+        <?php if (have_rows('carousel_products_1')) : ?>
+          <?php while (have_rows('carousel_products_1')) : the_row(); ?>
+            <?php
+            $product = get_sub_field('product');
+            $color = get_sub_field('product_background');
+            $product_images = get_field('product_images', $product);
+            if ($product_images) :
+              $first_image = $product_images[0];
+            ?>
+              <div class="carousel-item" style="background-color: <?= $color ?>">
+                <img src="<?php echo $first_image['url']; ?>" alt="<?php echo $first_image['alt']; ?>">
+              </div>
+            <?php endif; ?>
+          <?php endwhile; ?>
+        <?php endif; ?>
+        <?php if (have_rows('carousel_products_1')) : ?>
+          <?php while (have_rows('carousel_products_1')) : the_row(); ?>
+            <?php
+            $product = get_sub_field('product');
+            $color = get_sub_field('product_background');
+            $product_images = get_field('product_images', $product);
+            if ($product_images) :
+              $first_image = $product_images[0];
+            ?>
+              <div class="carousel-item" style="background-color: <?= $color ?>">
+                <img src="<?php echo $first_image['url']; ?>" alt="<?php echo $first_image['alt']; ?>">
+              </div>
+            <?php endif; ?>
+          <?php endwhile; ?>
+        <?php endif; ?>
+      </div>
     </div>
   </div>
   <!--  Pledge  -->
@@ -139,11 +168,40 @@ $product_carousel_2 = get_field('carousel_products_2');
   </div>
 
   <!--  Video  -->
-  <div class="mhome-12 w-100 mhome-row mhome-item mhome-item-video">
-    <div class="home-video">
-      <video autoplay muted loop>
-        <source src="/wp-content/uploads/2023/02/PackRoll1-25.webm" type="video/webm" />
-      </video>
+  <div class="mhome-12 w-100 mhome-row mhome-item mhome-item-video overflow-hidden">
+    <div id="carousel-2" class="image-carousel">
+      <div class="carousel-track">
+        <?php if (have_rows('carousel_products_2')) : ?>
+          <?php while (have_rows('carousel_products_2')) : the_row(); ?>
+            <?php
+            $product = get_sub_field('product');
+            $color = get_sub_field('product_background');
+            $product_images = get_field('product_images', $product);
+            if ($product_images) :
+              $first_image = $product_images[0];
+            ?>
+              <div class="carousel-item" style="background-color: <?= $color ?>">
+                <img src="<?php echo $first_image['url']; ?>" alt="<?php echo $first_image['alt']; ?>">
+              </div>
+            <?php endif; ?>
+          <?php endwhile; ?>
+        <?php endif; ?>
+        <?php if (have_rows('carousel_products_2')) : ?>
+          <?php while (have_rows('carousel_products_2')) : the_row(); ?>
+            <?php
+            $product = get_sub_field('product');
+            $color = get_sub_field('product_background');
+            $product_images = get_field('product_images', $product);
+            if ($product_images) :
+              $first_image = $product_images[0];
+            ?>
+              <div class="carousel-item" style="background-color: <?= $color ?>">
+                <img src="<?php echo $first_image['url']; ?>" alt="<?php echo $first_image['alt']; ?>">
+              </div>
+            <?php endif; ?>
+          <?php endwhile; ?>
+        <?php endif; ?>
+      </div>
     </div>
   </div>
   <!-- Good Food -->
@@ -152,11 +210,40 @@ $product_carousel_2 = get_field('carousel_products_2');
   </div>
 
   <!--  Video  -->
-  <div class="mhome-14 w-100 mhome-row mhome-item mhome-item-video">
-    <div class="home-video">
-      <video autoplay muted loop>
-        <source src="/wp-content/uploads/2023/02/PackRoll2-25.webm" type="video/webm" />
-      </video>
+  <div class="mhome-14 w-100 mhome-row mhome-item mhome-item-video overflow-hidden">
+    <div id="carousel-3" class="image-carousel">
+      <div class="carousel-track">
+        <?php if (have_rows('carousel_products_1')) : ?>
+          <?php while (have_rows('carousel_products_1')) : the_row(); ?>
+            <?php
+            $product = get_sub_field('product');
+            $color = get_sub_field('product_background');
+            $product_images = get_field('product_images', $product);
+            if ($product_images) :
+              $first_image = $product_images[0];
+            ?>
+              <div class="carousel-item" style="background-color: <?= $color ?>">
+                <img src="<?php echo $first_image['url']; ?>" alt="<?php echo $first_image['alt']; ?>">
+              </div>
+            <?php endif; ?>
+          <?php endwhile; ?>
+        <?php endif; ?>
+        <?php if (have_rows('carousel_products_1')) : ?>
+          <?php while (have_rows('carousel_products_1')) : the_row(); ?>
+            <?php
+            $product = get_sub_field('product');
+            $color = get_sub_field('product_background');
+            $product_images = get_field('product_images', $product);
+            if ($product_images) :
+              $first_image = $product_images[0];
+            ?>
+              <div class="carousel-item" style="background-color: <?= $color ?>">
+                <img src="<?php echo $first_image['url']; ?>" alt="<?php echo $first_image['alt']; ?>">
+              </div>
+            <?php endif; ?>
+          <?php endwhile; ?>
+        <?php endif; ?>
+      </div>
     </div>
   </div>
 
@@ -192,7 +279,7 @@ $product_carousel_2 = get_field('carousel_products_2');
                 if ($product_images) :
                   $first_image = $product_images[0];
                 ?>
-                  <div class="carousel-item" style="background-color: <?=$color?>">
+                  <div class="carousel-item" style="background-color: <?= $color ?>">
                     <img src="<?php echo $first_image['url']; ?>" alt="<?php echo $first_image['alt']; ?>">
                   </div>
                 <?php endif; ?>
@@ -207,7 +294,7 @@ $product_carousel_2 = get_field('carousel_products_2');
                 if ($product_images) :
                   $first_image = $product_images[0];
                 ?>
-                  <div class="carousel-item" style="background-color: <?=$color?>">
+                  <div class="carousel-item" style="background-color: <?= $color ?>">
                     <img src="<?php echo $first_image['url']; ?>" alt="<?php echo $first_image['alt']; ?>">
                   </div>
                 <?php endif; ?>
@@ -350,7 +437,7 @@ $product_carousel_2 = get_field('carousel_products_2');
                 if ($product_images) :
                   $first_image = $product_images[0];
                 ?>
-                  <div class="carousel-item" style="background-color: <?=$color?>">
+                  <div class="carousel-item" style="background-color: <?= $color ?>">
                     <img src="<?php echo $first_image['url']; ?>" alt="<?php echo $first_image['alt']; ?>">
                   </div>
                 <?php endif; ?>
@@ -365,7 +452,7 @@ $product_carousel_2 = get_field('carousel_products_2');
                 if ($product_images) :
                   $first_image = $product_images[0];
                 ?>
-                  <div class="carousel-item" style="background-color: <?=$color?>">
+                  <div class="carousel-item" style="background-color: <?= $color ?>">
                     <img src="<?php echo $first_image['url']; ?>" alt="<?php echo $first_image['alt']; ?>">
                   </div>
                 <?php endif; ?>
@@ -395,7 +482,7 @@ $product_carousel_2 = get_field('carousel_products_2');
                 if ($product_images) :
                   $first_image = $product_images[0];
                 ?>
-                  <div class="carousel-item" style="background-color: <?=$color?>">
+                  <div class="carousel-item" style="background-color: <?= $color ?>">
                     <img src="<?php echo $first_image['url']; ?>" alt="<?php echo $first_image['alt']; ?>">
                   </div>
                 <?php endif; ?>
@@ -410,7 +497,7 @@ $product_carousel_2 = get_field('carousel_products_2');
                 if ($product_images) :
                   $first_image = $product_images[0];
                 ?>
-                  <div class="carousel-item" style="background-color: <?=$color?>">
+                  <div class="carousel-item" style="background-color: <?= $color ?>">
                     <img src="<?php echo $first_image['url']; ?>" alt="<?php echo $first_image['alt']; ?>">
                   </div>
                 <?php endif; ?>


### PR DESCRIPTION
The client has asked that we implement a new product carousel on their homepage. To do this, we needed to replace the videos taht are currently serving this function and implement a pure css/php solution. 

Our approach was to create two different repeater fields in the WP Admin. These two fields allow the user to select 4 different products from the database to display in carousels. 

On the frontend, we are grabbing the first product image for each product in the repeaters and then outputting the image in a single-flex column. We are using css animation to make the images scroll vertically in the DOM.

This deployment will require migrating the ACF field groups for the homepage and re-adding products. 